### PR TITLE
fix: allowed types format

### DIFF
--- a/src/components/converter/converter-steps/upload-step/upload-step.tsx
+++ b/src/components/converter/converter-steps/upload-step/upload-step.tsx
@@ -48,6 +48,7 @@ const UploadStep = memo(function UploadStepComponent(props: Readonly<UploadStepP
         props.allowedUploadingFormats.forEach((type, index) => {
             if (index === props.allowedUploadingFormats.length - 1) {
                 types += type
+                return
             }
 
             types += type + ", "


### PR DESCRIPTION
Fixes #31 

The method that adds all allowed types to string was missing a return statement.
![image](https://github.com/CarlaPaiva/media-transmute/assets/51243239/1b2f2205-2efe-4599-a7f5-6b7c85f5cef4)
